### PR TITLE
Initialize gradient in HessianResult to avoid undef errors when

### DIFF
--- a/src/DiffResults.jl
+++ b/src/DiffResults.jl
@@ -104,7 +104,7 @@ Note that `HessianResult` allocates its own storage; `x` is only used for type a
 shape information. If you want to allocate storage yourself, use the `DiffResult`
 constructor instead.
 """
-HessianResult(x::AbstractArray) = DiffResult(first(x), similar(x), similar(x, length(x), length(x)))
+HessianResult(x::AbstractArray) = DiffResult(first(x), zeros(length(x)), similar(x, length(x), length(x)))
 HessianResult(x::StaticArray) = DiffResult(first(x), x, zeros(StaticArrays.similar_type(typeof(x), Size(length(x),length(x)))))
 
 #############


### PR DESCRIPTION
using BigFloats in Hessian computations

Fixes #8 

I wanted to add a test but that would require `ForwardDiff`, i.e. something like
```julia
# hessian! + BigFloat #
# -----------------------------#

xb = big.(ones(2))
rb = HessianResult(xb)
ForwardDiff.hessian!(rb, sqrt(prod(x)), xb)
@test hessian(rb) == big.([-1 1; 1 -1]/4)
```
Would you like the test added to `ForwardDiff`?