### PR TITLE
use StaticArraysCore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
+          - '1.6'
           - '1'
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 
 [compat]
 StaticArrays = "1.5.7"
-StaticArraysCore = "1.3.0"
+StaticArraysCore = "1.4.0"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,16 +1,18 @@
 name = "DiffResults"
 uuid = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
-version = "1.0.3"
+version = "1.1.0"
 
 [deps]
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 
 [compat]
-StaticArrays = "0.8, 0.9, 0.10, 0.11, 0.12, 1.0"
-julia = "1"
+StaticArrays = "1.5.7"
+StaticArraysCore = "1.3.0"
+julia = "1.6"
 
 [extras]
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "StaticArrays"]

--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,7 @@ version = "1.1.0"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 
 [compat]
-StaticArrays = "1.5.7"
+StaticArrays = "1.5.8"
 StaticArraysCore = "1.4.0"
 julia = "1.6"
 

--- a/src/DiffResults.jl
+++ b/src/DiffResults.jl
@@ -1,6 +1,6 @@
 module DiffResults
 
-using StaticArrays
+using StaticArraysCore: StaticArray, similar_type  #, Size  # Size is not yet in Core package
 
 #########
 # Types #
@@ -76,7 +76,8 @@ shape information. If you want to allocate storage yourself, use the `DiffResult
 constructor instead.
 """
 JacobianResult(x::AbstractArray) = DiffResult(similar(x), similar(x, length(x), length(x)))
-JacobianResult(x::StaticArray) = DiffResult(x, zeros(StaticArrays.similar_type(typeof(x), Size(length(x),length(x)))))
+# JacobianResult(x::StaticArray) = DiffResult(x, zeros(similar_type(typeof(x), Size(length(x),length(x)))))
+JacobianResult(x::StaticArray) = DiffResult(x, zeros(similar_type(typeof(x), (axes(vec(x))..., axes(vec(x))...))))
 
 """
     JacobianResult(y::AbstractArray, x::AbstractArray)
@@ -89,7 +90,8 @@ Like the single argument version, `y` and `x` are only used for type and
 shape information and are not stored in the returned `DiffResult`.
 """
 JacobianResult(y::AbstractArray, x::AbstractArray) = DiffResult(similar(y), similar(y, length(y), length(x)))
-JacobianResult(y::StaticArray, x::StaticArray) = DiffResult(y, zeros(StaticArrays.similar_type(typeof(x), Size(length(y),length(x)))))
+# JacobianResult(y::StaticArray, x::StaticArray) = DiffResult(y, zeros(similar_type(typeof(x), Size(length(y),length(x)))))
+JacobianResult(y::StaticArray, x::StaticArray) = DiffResult(y, zeros(similar_type(typeof(x), (axes(vec(y))..., axes(vec(x))...))))
 
 """
     HessianResult(x::AbstractArray)
@@ -102,7 +104,8 @@ shape information. If you want to allocate storage yourself, use the `DiffResult
 constructor instead.
 """
 HessianResult(x::AbstractArray) = DiffResult(first(x), zeros(eltype(x), size(x)), similar(x, length(x), length(x)))
-HessianResult(x::StaticArray) = DiffResult(first(x), x, zeros(StaticArrays.similar_type(typeof(x), Size(length(x),length(x)))))
+# HessianResult(x::StaticArray) = DiffResult(first(x), x, zeros(similar_type(typeof(x), Size(length(x),length(x)))))
+HessianResult(x::StaticArray) = DiffResult(first(x), x, zeros(similar_type(typeof(x), (axes(vec(x))..., axes(vec(x))...))))
 
 #############
 # Interface #

--- a/src/DiffResults.jl
+++ b/src/DiffResults.jl
@@ -1,6 +1,6 @@
 module DiffResults
 
-using StaticArraysCore: StaticArray, similar_type  #, Size  # Size is not yet in Core package
+using StaticArraysCore: StaticArray, similar_type, Size
 
 #########
 # Types #
@@ -76,8 +76,7 @@ shape information. If you want to allocate storage yourself, use the `DiffResult
 constructor instead.
 """
 JacobianResult(x::AbstractArray) = DiffResult(similar(x), similar(x, length(x), length(x)))
-# JacobianResult(x::StaticArray) = DiffResult(x, zeros(similar_type(typeof(x), Size(length(x),length(x)))))
-JacobianResult(x::StaticArray) = DiffResult(x, zeros(similar_type(typeof(x), (axes(vec(x))..., axes(vec(x))...))))
+JacobianResult(x::StaticArray) = DiffResult(x, zeros(similar_type(typeof(x), Size(length(x),length(x)))))
 
 """
     JacobianResult(y::AbstractArray, x::AbstractArray)
@@ -90,8 +89,7 @@ Like the single argument version, `y` and `x` are only used for type and
 shape information and are not stored in the returned `DiffResult`.
 """
 JacobianResult(y::AbstractArray, x::AbstractArray) = DiffResult(similar(y), similar(y, length(y), length(x)))
-# JacobianResult(y::StaticArray, x::StaticArray) = DiffResult(y, zeros(similar_type(typeof(x), Size(length(y),length(x)))))
-JacobianResult(y::StaticArray, x::StaticArray) = DiffResult(y, zeros(similar_type(typeof(x), (axes(vec(y))..., axes(vec(x))...))))
+JacobianResult(y::StaticArray, x::StaticArray) = DiffResult(y, zeros(similar_type(typeof(x), Size(length(y),length(x)))))
 
 """
     HessianResult(x::AbstractArray)
@@ -104,8 +102,7 @@ shape information. If you want to allocate storage yourself, use the `DiffResult
 constructor instead.
 """
 HessianResult(x::AbstractArray) = DiffResult(first(x), zeros(eltype(x), size(x)), similar(x, length(x), length(x)))
-# HessianResult(x::StaticArray) = DiffResult(first(x), x, zeros(similar_type(typeof(x), Size(length(x),length(x)))))
-HessianResult(x::StaticArray) = DiffResult(first(x), x, zeros(similar_type(typeof(x), (axes(vec(x))..., axes(vec(x))...))))
+HessianResult(x::StaticArray) = DiffResult(first(x), x, zeros(similar_type(typeof(x), Size(length(x),length(x)))))
 
 #############
 # Interface #


### PR DESCRIPTION
Replaces StaticArrays with StaticArraysCore. Needed for https://github.com/JuliaDiff/ForwardDiff.jl/pull/599

This means dropping Julia < 1.6.

There is a bit of a hack to get around the fact that `Size` isn't available. Looks like this is well-tested.