### PR TITLE
Test on pre-release instead of nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         version:
           - '1.6'
           - '1'
-          - 'nightly'
+          - 'pre'
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
This is a useful change but the real purpose is to re-trigger a docs build for the "latest" docs, now that I have fixed the documenter setup (which had stopped updating the pages for a while).