### PR TITLE
Update CI: Remove tests with AbstractDifferentiation and use julia-actions/cache

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -13,4 +13,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMPATHELPER_PRIV: ${{ secrets.DOCUMENTER_KEY }}  # optional
-        run: julia -e 'using CompatHelper; CompatHelper.main()'
+        run: julia -e 'using CompatHelper; CompatHelper.main(; dirs = ["", "docs"])'

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -22,7 +22,6 @@ jobs:
       fail-fast: false
       matrix:
         package:
-          - {user: JuliaDiff, repo: AbstractDifferentiation.jl, group: All}
           - {user: JuliaDiff, repo: ForwardDiff.jl, group: All}
           - {user: JuliaDiff, repo: ReverseDiff.jl, group: All}
           - {user: tpapp, repo: LogDensityProblemsAD.jl, group: All}
@@ -31,7 +30,6 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: 1
-          arch: x64
       - uses: julia-actions/julia-buildpkg@v1
       - name: Clone Downstream
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
     tags: '*'
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.version == 'pre' }}
     strategy:
@@ -22,24 +22,12 @@ jobs:
           - 'pre'
         os:
           - ubuntu-latest
-        arch:
-          - x64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: actions/cache@v4
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
@@ -56,11 +44,8 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
-      - run: |
-          julia --project=docs -e '
-            using Pkg
-            Pkg.develop(PackageSpec(path=pwd()))
-            Pkg.instantiate()'
+      - uses: julia-actions/cache@v2
+      - run: julia --project=docs -e 'import Pkg; Pkg.instantiate()'
       - run: |
           julia --project=docs -e '
             using Documenter: doctest

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -4,3 +4,6 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
 Documenter = "0.25"
+
+[sources.DiffResults]
+path = ".."


### PR DESCRIPTION
AFAIK AbstractDifferentiation is neither maintained nor used anymore, everyone is using DifferentiationInterface.